### PR TITLE
Stop new tabs from closing automatically

### DIFF
--- a/swc-background.js
+++ b/swc-background.js
@@ -16,9 +16,10 @@ const openInDifferentContainer = function(cookieStoreId, tab, urlOverride) {
     index: tab.index + 1,
     openerTabId: tab.openerTabId
   };
-
-  if (urlOverride || !blankPages.has(tab.url)) {
-    tabProperties.url = urlOverride || tab.url;
+  
+  const url = urlOverride || tab.url;
+  if (!blankPages.has(url)) {
+    tabProperties.url = url;
   }
 
   console.debug('openInDifferentContainer', tabProperties);


### PR DESCRIPTION
When a new tab is opened with URL `about:newtab` (aka "Firefox Home (Default)") and SWC is triggered, both `tab.url` and `details.url` are set to `about:newtab`, which leads to `openInDifferentContainer` being called with `urlOverride` `about:newtab`, and `browser.tabs.create` with `url: 'about:newtab'` (despite the `blankPages.has(url)` check), leading to an `Illegal URL: about:newtab` error, and the originally opened tab closing, without a new tab opening to replace it.

For reasons unclear to me, opening a new tab does not consistently trigger SWC--the Browser Console doesn't always show an `onBeforeNavigate` log message-- but when it does, this behavior shows consistently.