### PR TITLE
Add `about:preferences` to privileged URLs

### DIFF
--- a/swc-background.js
+++ b/swc-background.js
@@ -51,6 +51,7 @@ const isPrivilegedURL = function(url) {
   return url == 'about:config' ||
     url == 'about:debugging' ||
     url == 'about:addons' ||
+    url == 'about:preferences' ||
     url.startsWith('chrome:') ||
     url.startsWith('javascript:') ||
     url.startsWith('data:') ||


### PR DESCRIPTION
@chronakis I'm back with another bugfix (after https://github.com/chronakis/firefox-sticky-window-containers/pull/4)!

Calling `browser.tabs.create` with `url: 'about:preferences'` results in an `Illegal URL: about:preferences` error and no new tab, so it should be considered a privileged URL.