### PR TITLE
Mark all URLs beginning with "about:" as privileged

### DIFF
--- a/swc-background.js
+++ b/swc-background.js
@@ -48,20 +48,13 @@ const updateLastCookieStoreId = function(tab) {
 };
 
 const isPrivilegedURL = function(url) {
-  return url == 'about:config' ||
-    url == 'about:debugging' ||
-    url == 'about:addons' ||
-    url == 'about:home' ||
-    url == 'about:logins' ||
+  return url.startsWith('about:') ||
     url.startsWith('chrome:') ||
     url.startsWith('javascript:') ||
     url.startsWith('data:') ||
     url.startsWith('file:') ||
-    url.startsWith('moz-extension:') ||
-    url.startsWith('about:certificate') ||
-    url.startsWith('about:logins') ||
-    url.startsWith('about:preferences') ||
-    url.startsWith('about:config');
+    url.startsWith('moz-extension:');
+  
 }
 
 // Event flow is:


### PR DESCRIPTION
Instead of manually whitelisting pages like "about:config" it now includes any URL beginning with "about:", meaning all about pages can open correctly, such as "about:mozilla" and "about:protections" and do not face the issue discussed in Issue #8. It's simpler to filter all URLs starting with "about:" than to list every single privileged page.

Thanks to @uCZMG for their help with this as well.